### PR TITLE
farm public IPs label and fix bugs related to country filter

### DIFF
--- a/charts/tf-explorer/Chart.yaml
+++ b/charts/tf-explorer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v3.0.0-rc9
+version: v3.0.0-rc10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tf-explorer/values.yaml
+++ b/charts/tf-explorer/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: threefolddev/tf-explorer
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v3.0.0-rc9"
+  tag: "v3.0.0-rc10"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/index.yaml
+++ b/index.yaml
@@ -83,6 +83,16 @@ entries:
     version: v3.0.0-rc2
   - apiVersion: v2
     appVersion: 1.16.0
+    created: "2021-12-09T15:58:54.739987259+02:00"
+    description: A Helm chart for Kubernetes
+    digest: 30499e445daebdef11726a5452ddbffc12ac96dd907b5a7f498667b6e2ddf5e8
+    name: tf-explorer
+    type: application
+    urls:
+    - tf-explorer-v3.0.0-rc10.tgz
+    version: v3.0.0-rc10
+  - apiVersion: v2
+    appVersion: 1.16.0
     created: "2021-11-14T12:00:03.088932488+02:00"
     description: A Helm chart for Kubernetes
     digest: 21275d25e8fd602094eb408f66f6585aa6db9808e970759fbb13d0f992c76625
@@ -131,4 +141,4 @@ entries:
     urls:
     - tf-explorer-0.3.0.tgz
     version: 0.3.0
-generated: "2021-12-06T10:19:14.69569654+02:00"
+generated: "2021-12-09T15:58:54.739102545+02:00"

--- a/src/components/NodesDistribution.vue
+++ b/src/components/NodesDistribution.vue
@@ -113,7 +113,6 @@ export default class NodesDistribution extends Vue {
 
     for (const key in counter) {
       const path = this.map.querySelector(`path[id='${key}']`);
-      console.log({ path });
 
       if (!path) continue;
       path.setAttribute(

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -144,7 +144,7 @@ export default {
       return {
         ...node,
         publicIp: getFarmPublicIPs(state, node.farmId),
-        countryFullName: byInternet(country)?.country,
+        countryFullName: country && country?.length == 2 ? byInternet(country)?.country: country,
         farmingPolicyName: state.policies[node.farmingPolicyId],
         status: state.nodes_status[node.nodeId],
       };
@@ -176,7 +176,7 @@ export default {
         return {
           ...node,
           publicIPs: getFarmPublicIPs(state, node.farmId),
-          countryFullName: byInternet(country)?.country,
+          countryFullName: country && country?.length == 2 ? byInternet(country)?.country: country,
           farmingPolicyName: state.policies[node.farmingPolicyId],
           status: state.nodes_status[node.nodeId],
         };

--- a/src/views/Nodes.vue
+++ b/src/views/Nodes.vue
@@ -138,7 +138,7 @@ export default class Nodes extends Vue {
   headers = [
     { text: "ID", value: "nodeId" },
     { text: "Farm ID", value: "farmId", align: "center" },
-    { text: "Farm Public IPs", value: "publicIPs", align: "center" },
+    { text: "Farm Total Public IPs", value: "publicIPs", align: "center" },
     { text: "HRU", value: "hru", align: "center" },
     { text: "SRU", value: "sru", align: "center" },
     { text: "MRU", value: "mru", align: "center" },


### PR DESCRIPTION
### Changed 
- update the farm public Ips to be `farm total public Ips` to remove any confusion related to it 
- Fix listing in the `country filter`
- Fix filter the nodes using `country filter` to give the correct number of nodes
- Update helm and related image to use `v3.0.0-rc10` version


### Issue
- https://github.com/threefoldtech/tfchain_explorer/issues/88
- https://github.com/threefoldtech/tfchain_explorer/issues/89
- https://github.com/threefoldtech/tfchain_explorer/issues/90