### PR TITLE
remove status node filter in filters section

### DIFF
--- a/src/views/Nodes.vue
+++ b/src/views/Nodes.vue
@@ -224,13 +224,6 @@ export default class Nodes extends Vue {
       max: 1e12 * 10, // 1e12 is Terra and we want here 10 Terrabytes
     },
     ...this.activeFilters,
-    // {
-    //   label: "Nodes Status",
-    //   type: "condition",
-    //   active: false,
-    //   key: "status",
-    //   placeholder: ["Status", "Offline", "Online"],
-    // },
     {
       label: "Public IP",
       type: "comparison",

--- a/src/views/Nodes.vue
+++ b/src/views/Nodes.vue
@@ -133,7 +133,7 @@ import ComparisonFilter from "@/components/ComparisonFilter.vue";
 })
 export default class Nodes extends Vue {
   withGateway = false;
-  onlyOnline = false;
+  onlyOnline = true;
 
   headers = [
     { text: "ID", value: "nodeId" },
@@ -224,13 +224,13 @@ export default class Nodes extends Vue {
       max: 1e12 * 10, // 1e12 is Terra and we want here 10 Terrabytes
     },
     ...this.activeFilters,
-    {
-      label: "Nodes Status",
-      type: "condition",
-      active: false,
-      key: "status",
-      placeholder: ["Status", "Offline", "Online"],
-    },
+    // {
+    //   label: "Nodes Status",
+    //   type: "condition",
+    //   active: false,
+    //   key: "status",
+    //   placeholder: ["Status", "Offline", "Online"],
+    // },
     {
       label: "Public IP",
       type: "comparison",
@@ -247,9 +247,8 @@ export default class Nodes extends Vue {
       nodes = nodes.filter(({ publicConfig }) => publicConfig !== null);
     }
 
-    if (this.onlyOnline) {
-      nodes = nodes.filter(({ status }) => status === true);
-    }
+    nodes = nodes.filter(({ status }) => status === this.onlyOnline);
+    
 
     return nodes;
   }


### PR DESCRIPTION
- Remove node status filter from the filters section
- Update the online filter (under Gateway filter) to show the online and offline nodes (used to show all the nodes and online nodes only)
- Update the default value for online filter to show the online nodes

### Issues
https://github.com/threefoldtech/tfchain_explorer/issues/95