### PR TITLE
Validate the the nodes count in statistics page is the same as in nodes listing page

### DIFF
--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -159,7 +159,7 @@ export default {
         usedPublicIPs : usedPublicIps,
         countryFullName: country && country?.length == 2 ? byInternet(country)?.country: country,
         farmingPolicyName: state.policies[node.farmingPolicyId],
-        status: state.nodes_status[node.nodeId],
+        status: state.nodes_status[node.nodeId]? state.nodes_status[node.nodeId]: false,
       };
     });
   },
@@ -195,7 +195,7 @@ export default {
           usedPublicIPs : usedPublicIps,
           countryFullName: country && country?.length == 2 ? byInternet(country)?.country: country,
           farmingPolicyName: state.policies[node.farmingPolicyId],
-          status: state.nodes_status[node.nodeId],
+          status: state.nodes_status[node.nodeId]? state.nodes_status[node.nodeId]: false,
         };
       });
     },


### PR DESCRIPTION
### Changes 
- validate the node that its status is not undefined
- get the nodes count before getting the status from the grid proxy

### Issues
https://github.com/threefoldtech/tfchain_explorer/issues/118