### PR TITLE
disable ingress, update chart and image to use versoin v3.0.0-rc30 and build chart

### DIFF
--- a/charts/tf-explorer/Chart.yaml
+++ b/charts/tf-explorer/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v3.0.0-rc29
+version: v3.0.0-rc30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.0.0-rc29"
+appVersion: "v3.0.0-rc30"

--- a/charts/tf-explorer/values.yaml
+++ b/charts/tf-explorer/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: threefolddev/tf-explorer
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v3.0.0-rc29"
+  tag: "v3.0.0-rc30"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -44,7 +44,7 @@ service:
 
 ingress:
   # from https://github.com/threefoldtech/vdc-solutions-charts/blob/master/charts/taiga/values.yaml
-  enabled: true
+  enabled: false
   annotations:
     kubernetes.io/ingress.class: traefik
     ingress.kubernetes.io/ssl-passthrough: "true"

--- a/index.yaml
+++ b/index.yaml
@@ -62,6 +62,16 @@ entries:
     - tf-explorer-v3.0.0-rc4.tgz
     version: v3.0.0-rc4
   - apiVersion: v2
+    appVersion: v3.0.0-rc30
+    created: "2022-02-24T13:12:58.909560754+02:00"
+    description: A Helm chart for Kubernetes
+    digest: a0469fb7126134189bc55729606ff5e6d5f3fd846691358b54ead240f5c42c14
+    name: tf-explorer
+    type: application
+    urls:
+    - tf-explorer-v3.0.0-rc30.tgz
+    version: v3.0.0-rc30
+  - apiVersion: v2
     appVersion: 1.16.0
     created: "2021-11-21T09:28:57.793435694+02:00"
     description: A Helm chart for Kubernetes
@@ -73,7 +83,7 @@ entries:
     version: v3.0.0-rc3
   - apiVersion: v2
     appVersion: v3.0.0-rc29
-    created: "2022-02-23T15:18:28.611057505+02:00"
+    created: "2022-02-24T13:12:58.908936213+02:00"
     description: A Helm chart for Kubernetes
     digest: 8209a517017f81a5ffc241faa79fc71307c1b21b6ea4182123388f54d0b35ade
     name: tf-explorer
@@ -83,7 +93,7 @@ entries:
     version: v3.0.0-rc29
   - apiVersion: v2
     appVersion: v3.0.0-rc28
-    created: "2022-02-23T15:18:28.610631574+02:00"
+    created: "2022-02-24T13:12:58.908119232+02:00"
     description: A Helm chart for Kubernetes
     digest: bb178ffc83b8b4e8f056cec5931d93ed333b43aaccb42b8fe88a095e3da7cd01
     name: tf-explorer
@@ -93,7 +103,7 @@ entries:
     version: v3.0.0-rc28
   - apiVersion: v2
     appVersion: v3.0.0-rc27
-    created: "2022-02-23T15:18:28.609970587+02:00"
+    created: "2022-02-24T13:12:58.907037905+02:00"
     description: A Helm chart for Kubernetes
     digest: 4d834538844543a5dda6221d563f7623a90095b4156a0cd22d135b76ae3e5222
     name: tf-explorer
@@ -103,7 +113,7 @@ entries:
     version: v3.0.0-rc27
   - apiVersion: v2
     appVersion: v3.0.0-rc26
-    created: "2022-02-23T15:18:28.609153889+02:00"
+    created: "2022-02-24T13:12:58.905791996+02:00"
     description: A Helm chart for Kubernetes
     digest: efa08094ba0a4d4efd6e5628b77946784fca7b89167372891525d3665217c136
     name: tf-explorer
@@ -311,4 +321,4 @@ entries:
     urls:
     - tf-explorer-0.3.0.tgz
     version: 0.3.0
-generated: "2022-02-23T15:18:28.60832179+02:00"
+generated: "2022-02-24T13:12:58.904248792+02:00"


### PR DESCRIPTION
### Changes
- Disable ingress 
- update chart and image and build the chart 

### Issues
https://github.com/threefoldtech/tfchain_explorer/issues/159