### PR TITLE
Master statistics gridproxy

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -7,6 +7,7 @@ import getPricingPolicies from "@/utils/getPricingPolicies";
 import createDataRequests from "@/utils/createDataRequests";
 import isNodeOnline from "@/utils/isNodeOnline";
 import getChainData from "@/utils/getChainData";
+import { toArray } from "lodash";
 export enum ActionTypes {
     INIT_POLICIES = "initPolicies",
     INIT_PRICING_POLICIES = "initPricingPolicies",
@@ -25,19 +26,27 @@ export default {
             });
     },
     loadData({ state, commit }: ActionContext<IState, IState>) {
-        commit(MutationTypes.SET_LOAD, true);
-            apollo.defaultClient.query<GetTotalCountQueryType>({
-                query: getTotalCountQuery
-            })
-            .then(({ data }) => data)
+        fetch(`${window.configs.proxy_url}/stats`)
+        .then((data) => data.json())
         .then((data) => {
-            const { nodes, farms, twins, nodeContracts } = data;
-            state.nodeContractsNo = nodeContracts?.totalCount ?? 0
-            state.twinsNo = twins?.totalCount ?? 0;
+            const { nodes, farms, twins, contracts, publicIps,accessNodes,
+                 countries, gateways, totalCru, totalHru, totalMru,totalSru } = data;
+            state.nodeContractsNo = contracts;
+            state.twinsNo = twins;
+            state.farmsNo = farms;
+            state.nodesNo = nodes;
+            state.publicIpsNo = publicIps;
+            state.accessNodesNo = accessNodes;
+            state.countriesNo = countries;
+            state.gatewaysNo = gateways;
+            state.totalCru = totalCru;
+            state.totalHru = totalHru;
+            state.totalMru = totalMru;
+            state.totalSru = totalSru;
             
             return {
-                nodes: nodes.totalCount,
-                farms: farms.totalCount,
+                nodes: nodes,
+                farms: farms,
             };
         })
         .then(createDataRequests)

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,13 +1,9 @@
 import type { ActionContext } from "vuex";
 import type { IState } from "./state";
-import apollo from "@/plugins/apollo";
-import { getTotalCountQuery, GetTotalCountQueryType } from '../graphql/api';
 import { MutationTypes } from './mutations';
-import getPricingPolicies from "@/utils/getPricingPolicies";
 import createDataRequests from "@/utils/createDataRequests";
 import isNodeOnline from "@/utils/isNodeOnline";
 import getChainData from "@/utils/getChainData";
-import { toArray } from "lodash";
 export enum ActionTypes {
     INIT_POLICIES = "initPolicies",
     INIT_PRICING_POLICIES = "initPricingPolicies",

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -117,31 +117,18 @@ export function getStatistics(state: IState): IStatistics[] {
   if (!state.data) {
     return [];
   }
-  
-  const nodes = fallbackDataExtractor("nodes")(state);
-  const farms = fallbackDataExtractor('farms')(state);
-  const countries = [...new Set(nodes.map(node => node.country))]
-  const twinsNo = state.twinsNo;
-  const accessNodes = getAccessNodesCount(nodes)
-  const gateways = getGatewaysCount(nodes)
-  const cru = nodes.reduce((total, next) => total + BigInt(next.cru ?? 0), BigInt(0)).toString();
-  const hru = nodes.reduce((total, next) => total + BigInt(next.hru ?? 0), BigInt(0)).toString();
-  const sru = nodes.reduce((total, next) => total + BigInt(next.sru ?? 0), BigInt(0)).toString();
-  const mru = nodes.reduce((total, next) => total + BigInt(next.mru ?? 0), BigInt(0)).toString();
-  const publicIPsNo = farms.reduce((total, next) => total + BigInt(next.publicIPs.length ?? 0), BigInt(0)).toString();
-  
   return [
-    { id: 0, data: nodes.length, title: "Nodes", icon: "mdi-laptop" },
-    { id: 1, data: farms.length, title: "Farms", icon: "mdi-tractor" },
-    { id: 2, data: countries.length, title: "Countries", icon: "mdi-earth" },
-    { id: 3, data: cru, title: "Total CPUs", icon: "mdi-cpu-64-bit" },
-    { id: 4, data: toTeraOrGigaOrPeta(sru), title: "Total SSD", icon: "mdi-nas" },
-    { id: 5, data: toTeraOrGigaOrPeta(hru), title: "Total HDD", icon: "mdi-harddisk" },
-    { id: 6, data: toTeraOrGigaOrPeta(mru), title: "Total RAM", icon: "mdi-memory" },
-    { id: 7, data: accessNodes, title: "Access Nodes", icon: "mdi-gate" },
-    { id: 8, data: gateways, title: "Gateways", icon: "mdi-boom-gate-outline" },
-    { id: 9, data: twinsNo, title: "Twins", icon: "mdi-brain" },
-    { id: 10, data: publicIPsNo, title: "Public IPs", icon: "mdi-access-point" },
+    { id: 0, data: state.nodesNo, title: "Nodes", icon: "mdi-laptop" },
+    { id: 1, data: state.farmsNo, title: "Farms", icon: "mdi-tractor" },
+    { id: 2, data: state.countriesNo, title: "Countries", icon: "mdi-earth" },
+    { id: 3, data: state.totalCru, title: "Total CPUs", icon: "mdi-cpu-64-bit" },
+    { id: 4, data: toTeraOrGigaOrPeta(state.totalSru.toString()), title: "Total SSD", icon: "mdi-nas" },
+    { id: 5, data: toTeraOrGigaOrPeta(state.totalHru.toString()), title: "Total HDD", icon: "mdi-harddisk" },
+    { id: 6, data: toTeraOrGigaOrPeta(state.totalMru.toString()), title: "Total RAM", icon: "mdi-memory" },
+    { id: 7, data: state.accessNodesNo, title: "Access Nodes", icon: "mdi-gate" },
+    { id: 8, data: state.gatewaysNo, title: "Gateways", icon: "mdi-boom-gate-outline" },
+    { id: 9, data: state.twinsNo, title: "Twins", icon: "mdi-brain" },
+    { id: 10, data: state.publicIpsNo, title: "Public IPs", icon: "mdi-access-point" },
     { id: 11, data: state.nodeContractsNo, title: "Contracts", icon: "mdi-file-document-edit-outline" },
   ]
 }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -49,7 +49,17 @@ export interface IState {
   loading: boolean;
   nodes_status: { [key: number]: boolean };
   nodeContractsNo: number;
+  accessNodesNo: number;
+  countriesNo: number;
+  gatewaysNo: number;
+  totalCru: number;
+  totalSru: number;
+  totalHru: number;
+  totalMru: number;
+  farmsNo: number;
+  nodesNo: number;
   twinsNo: number;
+  publicIpsNo: number;
   versions: Array<{ name: string, value: any }>;
   filters: {
     nodes: {
@@ -90,6 +100,16 @@ export default {
   loading: false,
   nodes_status: {},
   nodeContractsNo: 0,
+  accessNodesNo: 0,
+  countriesNo: 0,
+  gatewaysNo: 0,
+  totalCru: 0,
+  totalSru: 0,
+  totalMru: 0,
+  totalHru: 0,
+  farmsNo: 0,
+  nodesNo: 0,
+  publicIpsNo: 0,
   versions: [],
   twinsNo: 0,
   filters: {

--- a/src/views/Farms.vue
+++ b/src/views/Farms.vue
@@ -69,9 +69,7 @@
         "
         @pagination="page = $event.page - 1" -->
         <template v-slot:[`item.certificationType`]="{ item }">
-          <v-chip :color="item.certificationType === 'Diy' ? 'red' : 'green'">
             {{ item.certificationType }}
-          </v-chip>
         </template>
 
         <template v-slot:[`item.publicIPs`]="{ item }">


### PR DESCRIPTION
### Changes
- update the statistics page to depend on gridproxy instead of graphql 
- remove the red label on the certification type on the farms' page (the red chip)

### Issues 
- https://github.com/threefoldtech/tfchain_explorer/issues/167